### PR TITLE
skipped build for python 3.5, use pillow 5.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
     - mswms_set_proj_lib_data_dir.patch 
     - mss_pyui_set_proj_lib_data_dir.patch
 build:
-  number: 1
+  skip: true  # [py35]
+  number: 2
   entry_points:
     - mss = mslib.msui.mss_pyui:main
     - mswms = mslib.mswms.mswms:main
@@ -37,7 +38,7 @@ requirements:
     - netcdf4
     - hdf4
     - paste
-    - pillow
+    - pillow 5.*
     - python-dateutil
     - pytz
     - pyqt 5.*


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ X] Used a fork of the feedstock to propose changes
* [ X] Bumped the build number (if the version is unchanged)
* [ X] Reset the build number to `0` (if the version changed)
* [ X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
conda-forge soon skips newer packages for python 3.5
https://twitter.com/condaforge/status/1045699331171528707
-->
